### PR TITLE
Updates for Twitch "beta"

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,12 +1,12 @@
 // These are variables for Twitch elements related to chat.
 // We expose them here so changes can be easily made if Twitch changes them.
-twitchChatUlClass = ".chat-lines";
-twitchChatMessageClass1 = ".message-line";
-twitchChatMessageClass2 = ".chat-line";
-twitchChatMessageContent = ".message";
+twitchChatUlClass = ".chat-list__lines .simplebar-scroll-content .simplebar-content .full-height";
+twitchChatMessageClass1 = ".chat-line__message";
+twitchChatMessageContent = "span:nth-child(4)";
 
 // Twitch chat message element: rich with media.
 var parseMsgHTML = function (msgHTML) {
+  //console.log(msgHTML.text());
   var contents = msgHTML.html(
     msgHTML
       .text()
@@ -26,7 +26,7 @@ function BardSearcher() {
             mutation.addedNodes.forEach(function (addedNode) {
                 // At this point it's potentially a chatMessage object.
                 var chatMessage = $(addedNode);
-                if (!chatMessage.is(twitchChatMessageClass1, twitchChatMessageClass2)) {
+                if (!chatMessage.is(twitchChatMessageClass1)) {
                     // this isn't a chat message, skip processing.
                     return;
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -16,20 +16,21 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.twitch.tv/*"],
+      "matches": ["https://go.twitch.tv/*"],
       "js": [
         "jquery-3.1.1.slim.min.js",
         "main.js"
       ],
       "css": [],
-      "exclude_globs": ["https://www.twitch.tv/directory/*",
-        "https://www.twitch.tv/p/*",
-        "https://www.twitch.tv/products/*",
-        "https://www.twitch.tv/*/manager*",
-        "https://www.twitch.tv/*/dashboard",
-        "https://www.twitch.tv/broadcast",
-        "https://www.twitch.tv/messages/*",
-        "https://www.twitch.tv/settings"
+      "exclude_globs": [
+        "https://go.twitch.tv/directory/*",
+        "https://go.twitch.tv/p/*",
+        "https://go.twitch.tv/products/*",
+        "https://go.twitch.tv/*/manager*",
+        "https://go.twitch.tv/*/dashboard",
+        "https://go.twitch.tv/broadcast",
+        "https://go.twitch.tv/messages/*",
+        "https://go.twitch.tv/settings"
       ],
       "run_at": "document_end"
     }


### PR DESCRIPTION
Twitch is currently testing a new website design which has been referred to as "beta". These are the code changes to keep up with them.

It looks like they have moved to using React. This doesn't mean anything to use, we just need to find the new classNames.

Users that are currently using this "beta" website are all public, non-logged-in users and logged-in users who *choose* to use the "beta" website. Delay merging until changes are permanent.

Thank you to @OwensC for pointing out these changes. Issue #1 